### PR TITLE
Use a separate thread for request processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Wagtailpurge Changelog
 
+## 0.4.0 (TBC)
+
+- Handle request processing in a separate thread using python's native `threading` module.
+
 ## 0.3.0 (2021-11-11)
 
 - Add the `URLPurgeRequest` request type.


### PR DESCRIPTION
Replace the non-functional asyncio stuff with a simple `threading` implementation, for processing requests.